### PR TITLE
Use spring class RequestContextUtils to determine current locale

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/spring/PebbleView.java
+++ b/src/main/java/com/mitchellbosecke/pebble/spring/PebbleView.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.web.servlet.support.RequestContextUtils;
 import org.springframework.web.servlet.view.AbstractTemplateView;
 
 import com.mitchellbosecke.pebble.PebbleEngine;
@@ -42,7 +43,7 @@ public class PebbleView extends AbstractTemplateView {
 
 		final Writer writer = response.getWriter();
 		try {
-			template.evaluate(writer, model, request.getLocale());
+			template.evaluate(writer, model, RequestContextUtils.getLocale(request));
 		} finally {
 			writer.flush();
 		}


### PR DESCRIPTION
I ran into issue with the way locale is currently determined by pebble. RequestContextUtils uses spring class LocaleResolver. If it's not used, it takes locale from request. Here's the snippet from RequestContextUtils.getLocale(...)

```java
public static Locale getLocale(HttpServletRequest request) {
    LocaleResolver localeResolver = getLocaleResolver(request);
    if (localeResolver != null) {
        return localeResolver.resolveLocale(request);
    }   
    return request.getLocale();
}
```